### PR TITLE
Add a SoyMapWrites type-class along with helper functions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,5 @@ src/main/webapp/WEB-INF/lib
 .DS_Store
 
 # Application specific
-/logs/application.log
 /.target/
 RUNNING_PID

--- a/src/main/scala/com/kinja/soy/Soy.scala
+++ b/src/main/scala/com/kinja/soy/Soy.scala
@@ -57,47 +57,4 @@ object Soy {
    * @return The result of the conversion.
    */
   def toSoyMap[T](o: T)(implicit writes: SoyMapWrites[T]): SoyMap = writes.toSoy(o)
-
-  /**
-   * Constructs a `SoyMapWrites[T]` sending the value to the given field name.
-   * @param field Name of the field the value will exist at.
-   */
-  def field[T](field: String)(implicit writes: SoyWrites[T]): SoyMapWrites[T] =
-    new SoyMapWrites[T] { def toSoy(t: T) = map(field -> t) }
-
-  /**
-   * Constructs a `SoyMapWrites[Option[T]]` sending the value to the given field name.
-   * if it is defined. Otherwise the SoyMap is empty.
-   * @param field Name of the field the value will exist at.
-   */
-  def optionalField[T](field: String)(implicit writes: SoyWrites[T]): SoyMapWrites[Option[T]] =
-    new SoyMapWrites[Option[T]] {
-      def toSoy(ot: Option[T]) = ot match {
-        case Some(t) => map(field -> t)
-        case None => map()
-      }
-    }
-
-  /**
-   * Constructs a `SoyMapWrites[T]` sending the value to the given field name.
-   * This is can be used in place of `field` when defining `SoyMapWrites` for
-   * recursive data structures.
-   * @param field Name of the field the value will exist at.
-   */
-  def lazyField[T](field: String)(writes: => SoyWrites[T]): SoyMapWrites[T] =
-    new SoyMapWrites[T] { def toSoy(t: T) = map(field -> writes.toSoy(t)) }
-
-  /**
-   * Constructs a `SoyMapWrites[Option[T]]` sending the value to the given field name.
-   * if it is defined. Otherwise the SoyMap is empty. This is can be used in place of
-   * `optionalField` when defining `SoyMapWrites` for recursive data structures.
-   * @param field Name of the field the value will exist at.
-   */
-  def lazyOptionalField[T](field: String)(writes: => SoyWrites[T]): SoyMapWrites[Option[T]] =
-    new SoyMapWrites[Option[T]] {
-      def toSoy(ot: Option[T]) = ot match {
-        case Some(t) => map(field -> writes.toSoy(t))
-        case None => map()
-      }
-    }
 }

--- a/src/main/scala/com/kinja/soy/SoyWrites.scala
+++ b/src/main/scala/com/kinja/soy/SoyWrites.scala
@@ -21,6 +21,25 @@ trait SoyWrites[-T] extends DefaultSoyWrites {
 object SoyWrites extends DefaultSoyWrites
 
 /**
+ * The class of types that can be converted into a SoyMap. Every SoyMapWrites implies a SoyWrites.
+ */
+trait SoyMapWrites[-T] extends SoyWrites[T] {
+  def toSoy(t: T): SoyMap
+  final def and[U](w: SoyMapWrites[U]): SoyMapWrites[(T, U)] = {
+    val _toSoy = toSoy _
+    new SoyMapWrites[(T, U)] {
+      def toSoy(tup: (T, U)) = _toSoy(tup._1) ++ w.toSoy(tup._2)
+    }
+  }
+  final def apply[U](f: U => T): SoyMapWrites[U] = {
+    val _toSoy = toSoy _
+    new SoyMapWrites[U] {
+      def toSoy(u: U) = _toSoy(f(u))
+    }
+  }
+}
+
+/**
  * Provides conversion from base types to SoyValue.
  */
 trait DefaultSoyWrites {

--- a/src/main/scala/com/kinja/soy/SoyWrites.scala
+++ b/src/main/scala/com/kinja/soy/SoyWrites.scala
@@ -25,18 +25,6 @@ object SoyWrites extends DefaultSoyWrites
  */
 trait SoyMapWrites[-T] extends SoyWrites[T] {
   def toSoy(t: T): SoyMap
-  final def and[U](w: SoyMapWrites[U]): SoyMapWrites[(T, U)] = {
-    val _toSoy = toSoy _
-    new SoyMapWrites[(T, U)] {
-      def toSoy(tup: (T, U)) = _toSoy(tup._1) ++ w.toSoy(tup._2)
-    }
-  }
-  final def apply[U](f: U => T): SoyMapWrites[U] = {
-    val _toSoy = toSoy _
-    new SoyMapWrites[U] {
-      def toSoy(u: U) = _toSoy(f(u))
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
@pozsi This PR creates a new `SoyMapWrites` type-class along with utility functions for using and constructing the type-class.

This change allows users to preserve type information when converting objects to Soy as they are usually converted to `SoyMap` which has extra functionality over other `SoyValue`s.

[Trello ticket](https://trello.com/c/OwFDvnAK/83-create-a-soymapwrites-type-class)
