### PR TITLE
Create a new Soy.writes macro to generate SoyMapWrites instances for case classes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "com.kinja"
 
 version := "0.3.4" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
 
-crossScalaVersions := Seq("2.10.5", "2.11.6")
+crossScalaVersions := Seq("2.10.4", "2.11.6")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
@@ -21,8 +21,20 @@ libraryDependencies ++= Seq(
 	"com.google.guava" % "guava" % "17.0" % "test",
 	"org.specs2" %% "specs2-core" % "2.4.15" % "test",
 	"org.specs2" %% "specs2-mock" % "2.4.15" % "test",
-	"org.specs2" %% "specs2-junit" % "2.4.15" % "test"
+	"org.specs2" %% "specs2-junit" % "2.4.15" % "test",
+	"org.scalatest" %% "scalatest" % "2.2.1" % "test"
 )
+
+libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-compiler" % _)
+
+libraryDependencies ++= {
+	CrossVersion.partialVersion(scalaVersion.value) match {
+		case Some((2, scalaMajor)) if scalaMajor >= 11 => Seq()
+		case Some((2, 10)) => Seq(
+			"org.scalamacros" %% "quasiquotes" % "2.0.1",
+			compilerPlugin("org.scalamacros" % "paradise_2.10.4" % "2.0.1"))
+	}
+}
 
 // Publishing
 

--- a/src/main/scala/com/kinja/soy/Soy.scala
+++ b/src/main/scala/com/kinja/soy/Soy.scala
@@ -1,6 +1,7 @@
 package com.kinja.soy
 
 import scala.language.implicitConversions
+import scala.language.experimental.macros
 
 /**
  * Provides convenience methods for building SoyValues.
@@ -57,4 +58,9 @@ object Soy {
    * @return The result of the conversion.
    */
   def toSoyMap[T](o: T)(implicit writes: SoyMapWrites[T]): SoyMap = writes.toSoy(o)
+
+  /**
+   * Generates a SoyMapWrites[T] for a given case class T.
+   */
+  def writes[T]: SoyMapWrites[T] = macro SoyMacroImpl.writesImpl[T]
 }

--- a/src/main/scala/com/kinja/soy/SoyMacroImpl.scala
+++ b/src/main/scala/com/kinja/soy/SoyMacroImpl.scala
@@ -1,0 +1,165 @@
+package com.kinja.soy
+
+import scala.language.higherKinds
+import scala.reflect.macros.Context
+import language.experimental.macros
+
+object SoyMacroImpl {
+
+  def writesImpl[A](c: Context)(implicit atag: c.WeakTypeTag[A]): c.Expr[SoyMapWrites[A]] = {
+
+    import c.universe._
+    import c.universe.Flag._
+
+    val soyWrites = c.universe.weakTypeTag[SoyWrites[_]]
+    val soyMapWrites = c.universe.weakTypeTag[SoyMapWrites[_]]
+
+    val companioned = weakTypeOf[A].typeSymbol
+    val companionSymbol = companioned.companionSymbol
+    val companionType = companionSymbol.typeSignature
+
+    val soyPkg = Select(Select(Ident(newTermName("com")), newTermName("kinja")), newTermName("soy"))
+
+    val soy = Select(soyPkg, newTermName("Soy"))
+    val writesSelect = Select(soyPkg, newTermName("SoyWrites"))
+    val lazyHelperSelect = Select(Select(soyPkg, newTermName("util")), newTypeName("Lazy"))
+
+    val candidateUnapply = companionType.declaration(newTermName("unapply"))
+    val candidateUnapplySeq = companionType.declaration(newTermName("unapplySeq"))
+    val hasVarArgs = candidateUnapplySeq != NoSymbol
+
+    val unapply = (candidateUnapply, candidateUnapplySeq) match {
+      case (s, _) if s != NoSymbol => s.asMethod
+      case (_, s) if s != NoSymbol => s.asMethod
+      case _ => c.abort(c.enclosingPosition, "No unapply or unapplySeq function found")
+    }
+
+    val unapplyReturnTypes: Option[List[Type]] = unapply.returnType match {
+      case TypeRef(_, _, Nil) => {
+        None
+      }
+      case TypeRef(_, _, args) =>
+        args.head match {
+          case t @ TypeRef(_, _, Nil) => Some(List(t))
+          case t @ TypeRef(_, _, args) => {
+            import c.universe.definitions.TupleClass
+            if (!TupleClass.seq.exists(tupleSym => t.baseType(tupleSym) ne NoType)) Some(List(t))
+            else if (t <:< typeOf[Product]) Some(args)
+            else None
+          }
+          case _ => None
+        }
+      case _ => None
+    }
+
+    val applies =
+      companionType.declaration(stringToTermName("apply")) match {
+        case NoSymbol => c.abort(c.enclosingPosition, "No apply function found")
+        case s => s.asMethod.alternatives
+      }
+
+    // Find the apply method that matches the unapply method.
+    val apply = applies.collectFirst {
+      case (apply: MethodSymbol) if hasVarArgs && {
+        val someApplyTypes = apply.paramss.headOption.map(_.map(_.asTerm.typeSignature))
+        val someInitApply = someApplyTypes.map(_.init)
+        val someApplyLast = someApplyTypes.map(_.last)
+        val someInitUnapply = unapplyReturnTypes.map(_.init)
+        val someUnapplyLast = unapplyReturnTypes.map(_.last)
+        val initsMatch = someInitApply == someInitUnapply
+        val lastMatch = (for {
+          lastApply <- someApplyLast
+          lastUnapply <- someUnapplyLast
+        } yield lastApply <:< lastUnapply).getOrElse(false)
+        initsMatch && lastMatch
+      } => apply
+      case (apply: MethodSymbol) if (apply.paramss.headOption.map(_.map(_.asTerm.typeSignature)) == unapplyReturnTypes) => apply
+    }
+
+    val params = apply match {
+      case Some(apply) => apply.paramss.head //verify there is a single parameter group
+      case None if unapplyReturnTypes.isEmpty => List.empty // The case class has no parameters.
+      case None => c.abort(c.enclosingPosition, "No apply function found matching unapply parameters")
+    }
+
+    final case class Implicit(paramName: Name, paramType: Type, neededImplicit: Tree, isRecursive: Boolean, tpe: Type)
+
+    def implicitSoyWrites(name: Name, typ: c.universe.type#Type) = {
+      val isRecursive = typ match {
+        case TypeRef(_, t, args) =>
+          args.exists(_.typeSymbol == companioned)
+        case TypeRef(_, t, _) => false
+      }
+
+      // Infer an implicit SoyWrites[typ]
+      val soyWritesTyp = c.inferImplicitValue(
+        appliedType(soyWrites.tpe.typeConstructor, List(typ)))
+      Implicit(name, typ, soyWritesTyp, isRecursive, typ)
+    }
+
+    val applyParamImplicits = params.map(param => implicitSoyWrites(param.name, param.typeSignature))
+    val inferredImplicits = if (hasVarArgs) {
+      val varArgsImplicit = implicitSoyWrites(
+        applyParamImplicits.last.paramName,
+        unapplyReturnTypes.get.last)
+      applyParamImplicits.init :+ varArgsImplicit
+    } else
+      applyParamImplicits
+
+    // Collect missing implicits then abort with an error message for each missing implicit.
+    val missingImplicits = inferredImplicits.collect {
+      case Implicit(_, t, impl, rec, _) if (impl == EmptyTree && !rec) => t
+    }
+    if (missingImplicits.nonEmpty)
+      c.abort(c.enclosingPosition, s"No implicit SoyWrites for ${missingImplicits.mkString(", ")} available.")
+
+    val lazyVal = Select(Ident(newTermName("self")), newTermName("lazyVal"))
+    // Select a higher-kinded implicit constructor from SoyWrites.
+    def hkImpl(methodName: String): Tree =
+      Apply(Select(writesSelect, newTermName(methodName)), List(lazyVal))
+
+    var hasRec = false
+
+    // Collect all the class members into `("fieldName", clazz.fieldName)` pairs.
+    val pairs = inferredImplicits.map {
+      case Implicit(name, t, impl, rec, tpe) =>
+        if (!rec)
+          q"(${name.decoded}, $soy.toSoy(clazz.${name.toTermName})($impl))"
+        else {
+          hasRec = true
+          val lazyImpl =
+            if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
+              hkImpl("OptionSoy")
+            else if (tpe.typeConstructor <:< typeOf[Array[_]].typeConstructor)
+              hkImpl("arraySoy")
+            else if (tpe.typeConstructor <:< typeOf[Map[_, _]].typeConstructor)
+              hkImpl("mapSoy")
+            else if (tpe.typeConstructor <:< typeOf[Traversable[_]].typeConstructor)
+              hkImpl("traversableSoy")
+            else
+              lazyVal
+          q"(${name.decoded}, $soy.toSoy(clazz.${name.toTermName})($lazyImpl))"
+        }
+    }
+
+    val soyMapWritesDef =
+      q"new SoyMapWrites[$atag] { def toSoy(clazz: $atag) = $soy.map(..$pairs) }"
+
+    // Recursive types must be constructed using Lazy.
+    if (!hasRec)
+      c.Expr[SoyMapWrites[A]](soyMapWritesDef)
+    else {
+      val soyMapWritesA = AppliedTypeTree(
+        Ident(soyMapWrites.tpe.typeSymbol),
+        List(Ident(atag.tpe.typeSymbol)))
+      val block = q"""{
+        new $lazyHelperSelect[$soyMapWritesA] { self =>
+          override lazy val lazyVal : $soyMapWritesA = $soyMapWritesDef
+        }
+      }.lazyVal"""
+
+      c.Expr[SoyMapWrites[A]](block)
+    }
+  }
+
+}

--- a/src/main/scala/com/kinja/soy/util/Lazy.scala
+++ b/src/main/scala/com/kinja/soy/util/Lazy.scala
@@ -1,0 +1,13 @@
+package com.kinja.soy.util
+
+/**
+ * Lazy is useful for creating SoyWrites for recursive data structures.
+ */
+trait Lazy[A] {
+  def lazyVal: A
+}
+object Lazy {
+  def apply[A](a: => A) = new Lazy[A] {
+    override lazy val lazyVal = a
+  }
+}

--- a/src/test/scala/com/kinja/soy/WritesMacroSpec.scala
+++ b/src/test/scala/com/kinja/soy/WritesMacroSpec.scala
@@ -1,0 +1,183 @@
+package com.kinja.soy
+
+import org.scalatest._
+
+case class EmptyClass()
+case class OptionClass(i: Int, s: Option[String])
+case class RecOptionClass(i: Int, b: Option[RecOptionClass])
+case class RecListClass(i: Int, b: List[RecListClass])
+case class RecSetClass(i: Int, b: Set[RecSetClass])
+case class RecMapClass(i: Int, b: Map[String, RecMapClass])
+case class Single(i: Int)
+case class Pair(i: Int, d: Double)
+case class Triple(i: Int, d: Double, l: Long)
+case class Quad(i: Int, d: Double, l: Long, s: String)
+case class Quint(a: Int, b: Int, c: Int, d: Int, e: Int)
+case class Sext(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int)
+case class Sept(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int)
+case class Oct(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int)
+case class Non(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int, i: Int)
+case class Dec(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int, i: Int, j: Int)
+case class Inner(i: Int)
+case class Outer(i: Int, inner: Inner)
+
+class WritesMacroSpec extends FlatSpec with Matchers {
+  implicit val z: SoyWrites[OptionClass] = Soy.writes[OptionClass]
+  implicit val b: SoyWrites[RecOptionClass] = Soy.writes[RecOptionClass]
+  implicit val c: SoyWrites[RecListClass] = Soy.writes[RecListClass]
+  implicit val d: SoyWrites[RecSetClass] = Soy.writes[RecSetClass]
+  implicit val f: SoyWrites[RecMapClass] = Soy.writes[RecMapClass]
+  implicit val g: SoyWrites[Single] = Soy.writes[Single]
+  implicit val h: SoyWrites[Pair] = Soy.writes[Pair]
+  implicit val i: SoyWrites[Triple] = Soy.writes[Triple]
+  implicit val j: SoyWrites[Quad] = Soy.writes[Quad]
+  implicit val k: SoyWrites[Quint] = Soy.writes[Quint]
+  implicit val l: SoyWrites[Sext] = Soy.writes[Sext]
+  implicit val m: SoyWrites[Sept] = Soy.writes[Sept]
+  implicit val n: SoyWrites[Oct] = Soy.writes[Oct]
+  implicit val o: SoyWrites[Non] = Soy.writes[Non]
+  implicit val p: SoyWrites[Dec] = Soy.writes[Dec]
+  implicit val q: SoyWrites[EmptyClass] = Soy.writes[EmptyClass]
+  implicit val r: SoyWrites[Inner] = Soy.writes[Inner]
+  implicit val s: SoyWrites[Outer] = Soy.writes[Outer]
+
+  "Soy.writes" should "support empty case classes" in {
+    Soy.toSoy(EmptyClass()) should be(Soy.map())
+  }
+
+  it should "support nested case classes" in {
+    val inner = Inner(1)
+    val outer = Outer(2, inner)
+    Soy.toSoy(outer) should be(Soy.map("i" -> 2, "inner" -> Soy.map("i" -> 1)))
+  }
+
+  it should "support case classes with optional members" in {
+    Soy.toSoy(OptionClass(5, None)) should be(Soy.map("i" -> 5, "s" -> SoyNull))
+    Soy.toSoy(OptionClass(5, Some("foo"))) should be(Soy.map("i" -> 5, "s" -> "foo"))
+  }
+
+  it should "support recursive case classes with optional members" in {
+    val b1 = RecOptionClass(1, None)
+    val b2 = RecOptionClass(2, Some(b1))
+    Soy.toSoy(b1) should be(Soy.map("i" -> 1, "b" -> SoyNull))
+    Soy.toSoy(b2) should be(Soy.map("i" -> 2, "b" -> Soy.map("i" -> 1, "b" -> SoyNull)))
+  }
+
+  it should "support recursive case classes with list members" in {
+    val b1 = RecListClass(1, Nil)
+    val b2 = RecListClass(2, List(b1))
+    Soy.toSoy(b1) should be(Soy.map("i" -> 1, "b" -> Soy.list()))
+    Soy.toSoy(b2) should be(Soy.map("i" -> 2, "b" -> Soy.list(Soy.map("i" -> 1, "b" -> Soy.list()))))
+  }
+
+  it should "support recursive case classes with set members" in {
+    val b1 = RecSetClass(1, Set.empty)
+    val b2 = RecSetClass(2, Set(b1))
+    Soy.toSoy(b1) should be(Soy.map("i" -> 1, "b" -> Soy.list()))
+    Soy.toSoy(b2) should be(Soy.map("i" -> 2, "b" -> Soy.list(Soy.map("i" -> 1, "b" -> Soy.list()))))
+  }
+
+  it should "support recursive case classes with map members" in {
+    val b1 = RecMapClass(1, Map.empty)
+    val b2 = RecMapClass(2, Map("b1" -> b1))
+    Soy.toSoy(b1) should be(Soy.map("i" -> 1, "b" -> Soy.map()))
+    Soy.toSoy(b2) should be(Soy.map("i" -> 2, "b" -> Soy.map("b1" -> Soy.map("i" -> 1, "b" -> Soy.map()))))
+  }
+
+  it should "support case classes with 1 member" in {
+    Soy.toSoy(Single(5)) should be(Soy.map("i" -> 5))
+  }
+
+  it should "support case classes with 2 members" in {
+    Soy.toSoy(Pair(1, 2.0)) should be(Soy.map("i" -> 1, "d" -> 2.0))
+  }
+
+  it should "support case classes with 3 members" in {
+    Soy.toSoy(Triple(1, 2.0, 3L)) should be(Soy.map("i" -> 1, "d" -> 2.0, "l" -> 3L))
+  }
+
+  it should "support case classes with 4 members" in {
+    Soy.toSoy(Quad(1, 2.0, 3L, "4")) should be(Soy.map("i" -> 1, "d" -> 2.0, "l" -> 3L, "s" -> "4"))
+  }
+
+  it should "support case classes with 5 members" in {
+    val clazz = Quint(1, 2, 3, 4, 5)
+    val map = Soy.map(
+      "a" -> 1,
+      "b" -> 2,
+      "c" -> 3,
+      "d" -> 4,
+      "e" -> 5)
+    Soy.toSoy(clazz) should be(map)
+  }
+
+  it should "support case classes with 6 members" in {
+    val clazz = Sext(1, 2, 3, 4, 5, 6)
+    val map = Soy.map(
+      "a" -> 1,
+      "b" -> 2,
+      "c" -> 3,
+      "d" -> 4,
+      "e" -> 5,
+      "f" -> 6)
+    Soy.toSoy(clazz) should be(map)
+  }
+
+  it should "support case classes with 7 members" in {
+    val clazz = Sept(1, 2, 3, 4, 5, 6, 7)
+    val map = Soy.map(
+      "a" -> 1,
+      "b" -> 2,
+      "c" -> 3,
+      "d" -> 4,
+      "e" -> 5,
+      "f" -> 6,
+      "g" -> 7)
+    Soy.toSoy(clazz) should be(map)
+  }
+
+  it should "support case classes with 8 members" in {
+    val clazz = Oct(1, 2, 3, 4, 5, 6, 7, 8)
+    val map = Soy.map(
+      "a" -> 1,
+      "b" -> 2,
+      "c" -> 3,
+      "d" -> 4,
+      "e" -> 5,
+      "f" -> 6,
+      "g" -> 7,
+      "h" -> 8)
+    Soy.toSoy(clazz) should be(map)
+  }
+
+  it should "support case classes with 9 members" in {
+    val clazz = Non(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    val map = Soy.map(
+      "a" -> 1,
+      "b" -> 2,
+      "c" -> 3,
+      "d" -> 4,
+      "e" -> 5,
+      "f" -> 6,
+      "g" -> 7,
+      "h" -> 8,
+      "i" -> 9)
+    Soy.toSoy(clazz) should be(map)
+  }
+
+  it should "support case classes with 10 members" in {
+    val clazz = Dec(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    val map = Soy.map(
+      "a" -> 1,
+      "b" -> 2,
+      "c" -> 3,
+      "d" -> 4,
+      "e" -> 5,
+      "f" -> 6,
+      "g" -> 7,
+      "h" -> 8,
+      "i" -> 9,
+      "j" -> 10)
+    Soy.toSoy(clazz) should be(map)
+  }
+}


### PR DESCRIPTION
@pozsi This PR creates the [`Soy.writes` macro](https://trello.com/c/dWJMGdxM/82-create-soy-writes-macro) which generates instances of `SoyMapWrites` for case classes.

Diff here: https://github.com/gawkermedia/soy/compare/SoyMapWrites...nonCombinatorMacro
