### PR TITLE
Support Generic Case Classes with the Soy.Writes macro.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "soy"
 organization := "com.kinja"
 
 // We use Semantic Versioning. See: http://semver.org/
-version := "0.4.1" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
+version := "0.4.2" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
 
 crossScalaVersions := Seq("2.10.4", "2.11.6")
 

--- a/src/test/scala/com/kinja/soy/SoyWritesSpec.scala
+++ b/src/test/scala/com/kinja/soy/SoyWritesSpec.scala
@@ -8,6 +8,8 @@ class SoyWritesSpec extends Specification {
 
   case class Simple(value: Int)
 
+  case class Other(a: Int)
+
   case class Complex(a: Int, b: String, c: Long, d: Simple)
 
   class SimpleSoy extends SoyWrites[Simple] {
@@ -20,6 +22,10 @@ class SoyWritesSpec extends Specification {
       "b" -> complex.b,
       "c" -> complex.c,
       "d" -> complex.d)
+  }
+
+  implicit val otherSoy = new SoyMapWrites[Other] {
+    def toSoy(other: Other): SoyMap = Soy.map("a" -> other.a)
   }
 
   implicit val simpleSoy = new SimpleSoy
@@ -273,6 +279,15 @@ class SoyWritesSpec extends Specification {
       soyValue must beAnInstanceOf[SoyMap]
       built must beAnInstanceOf[SoyMapData]
       built.toString must_== "{a: 1, b: a, c: 11, d: Simple(111)}"
+    }
+  }
+
+  "SoyMapWrites" should {
+    "function as SoyWrites" in {
+      val other = Other(5)
+      val soyValue = Soy.toSoy(other)
+      soyValue must beAnInstanceOf[SoyValue]
+      soyValue must_== Soy.map("a" -> 5)
     }
   }
 


### PR DESCRIPTION
@pozsi This PR extends the `writes` macro with support for generic classes.

``` scala
case class Foo[A](a : A)
object Foo {
   // This now works. Previously reported "No apply function found matching unapply parameters".
   implicit def Foo_SoyMapWrites[A : SoyMapWrites] = Soy.writes[Foo[A]]
}
```
## Testing

Try everything you can to break the macro or get it to generate an incorrect instance.
