### PR TITLE
SoyMap underlying type switched over to Map

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "soy"
 organization := "com.kinja"
 
 // We use Semantic Versioning. See: http://semver.org/
-version := "0.4.4" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
+version := "0.5.0" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
 
 crossScalaVersions := Seq("2.10.4", "2.11.6")
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "soy"
 organization := "com.kinja"
 
 // We use Semantic Versioning. See: http://semver.org/
-version := "0.5.0" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
+version := "1.0.0" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
 
 crossScalaVersions := Seq("2.10.4", "2.11.6")
 

--- a/src/main/scala/com/kinja/soy/Soy.scala
+++ b/src/main/scala/com/kinja/soy/Soy.scala
@@ -43,7 +43,7 @@ object Soy {
    * @return The soy map.
    */
   def map(items: (String, SoyValueWrapper)*): SoyMap =
-    SoyMap(items.map { case (k, v) => (k, v.asInstanceOf[SoyValueWrapperImpl].field) })
+    SoyMap(items.map { case (k, v) => (k, v.asInstanceOf[SoyValueWrapperImpl].field) }.toMap)
 
   /**
    * Converts a value of any type to SoyValue using its implicit SoyWrites.

--- a/src/main/scala/com/kinja/soy/SoyValue.scala
+++ b/src/main/scala/com/kinja/soy/SoyValue.scala
@@ -42,35 +42,35 @@ case class SoyList(value: Seq[SoyValue]) extends AnyVal with SoyValue {
   def build = new SoyListData(asJavaIterable(value.map(_.build)))
 }
 
-case class SoyMap(fields: Seq[(String, SoyValue)]) extends AnyVal with SoyValue {
+case class SoyMap(value: Map[String, SoyValue]) extends AnyVal with SoyValue {
 
-  def build = new SoyMapData(mapAsJavaMap(Map(fields.map { case (k, v) => (k, v.build) }: _*)))
+  def build = new SoyMapData(mapAsJavaMap(value.map { case (k, v) => k -> v.build }))
 
   /**
    * All distinct keys of the map.
    */
-  def keys: Set[String] = fields.map(_._1).toSet
+  def keys: Set[String] = value.map(_._1).toSet
 
   /**
    * All distinct values of the map.
    */
-  def values: Set[SoyValue] = fields.map(_._2).toSet
+  def values: Set[SoyValue] = value.map(_._2).toSet
 
   /**
    * Merge this map with an other one. Values from other override value of the current map.
    */
   def ++(other: SoyMap): SoyMap = {
-    val otherKeys = other.keys
-    SoyMap(fields.filterNot(v => otherKeys(v._1)) ++ other.fields)
+    SoyMap(value ++ other.value)
   }
 
   /**
    * Removes a key from the map.
    */
-  def -(key: String): SoyMap = SoyMap(fields.filterNot(_._1 == key))
+  def -(key: String): SoyMap = SoyMap(value.filterNot(_._1 == key))
 
   /**
    * Appends a key-value pair to the map.
    */
-  def +(field: (String, SoyValue)): SoyMap = SoyMap(fields :+ field)
+  def +(field: (String, SoyValue)): SoyMap = SoyMap(value + field)
+
 }

--- a/src/main/scala/com/kinja/soy/SoyWrites.scala
+++ b/src/main/scala/com/kinja/soy/SoyWrites.scala
@@ -120,7 +120,7 @@ trait DefaultSoyWrites {
    * Converter for Map[String,V] types.
    */
   implicit def mapSoy[V](implicit writes: SoyWrites[V]): SoyWrites[collection.immutable.Map[String, V]] = new SoyWrites[collection.immutable.Map[String, V]] {
-    def toSoy(ts: collection.immutable.Map[String, V]) = SoyMap(ts.map { case (k, v) => (k, Soy.toSoy(v)(writes)) }.toSeq)
+    def toSoy(ts: collection.immutable.Map[String, V]) = SoyMap(ts.map { case (k, v) => (k, Soy.toSoy(v)(writes)) }.toMap)
   }
 
   /**

--- a/src/test/scala/com/kinja/soy/SoyMapSpec.scala
+++ b/src/test/scala/com/kinja/soy/SoyMapSpec.scala
@@ -6,113 +6,113 @@ class SoyMapSpec extends Specification {
 
   "keys" should {
     "return empty set for empty map" in {
-      val map: SoyMap = SoyMap(Seq())
+      val map: SoyMap = SoyMap(Map())
       map.keys === Set()
     }
     "return correct keys for a non-empty map" in {
-      val map: SoyMap = SoyMap(Seq(("key1", SoyNull), ("key2", SoyString("hello")), ("key3", SoyInt(12))))
+      val map: SoyMap = SoyMap(Map("key1" -> SoyNull, "key2" -> SoyString("hello"), "key3" -> SoyInt(12)))
       map.keys === Set("key1", "key2", "key3")
     }
     "not return duplicates" in {
-      val map: SoyMap = SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("hello")), ("key2", SoyInt(12))))
+      val map: SoyMap = SoyMap(Map("key1" -> SoyNull, "key1" -> SoyString("hello"), "key2" -> SoyInt(12)))
       map.keys === Set("key1", "key2")
     }
   }
 
   "values" should {
     "return empty set for empty map" in {
-      val map: SoyMap = SoyMap(Seq())
+      val map: SoyMap = SoyMap(Map())
       map.values === Set()
     }
-    "return correct keys for a non-empty map" in {
-      val map: SoyMap = SoyMap(Seq(("key1", SoyNull), ("key2", SoyString("hello")), ("key3", SoyInt(12))))
+    "return correct values for a non-empty map" in {
+      val map: SoyMap = SoyMap(Map("key1" -> SoyNull, "key2" -> SoyString("hello"), "key3" -> SoyInt(12)))
       map.values === Set(SoyNull, SoyString("hello"), SoyInt(12))
     }
     "not return duplicates" in {
-      val map: SoyMap = SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("hello")), ("key2", SoyInt(12)), ("key2", SoyNull)))
+      val map: SoyMap = SoyMap(Map("key1" -> SoyNull, "key2" -> SoyString("hello"), "key3" -> SoyInt(12), "key4" -> SoyNull))
       map.values === Set(SoyNull, SoyString("hello"), SoyInt(12))
     }
   }
 
   "++" should {
     "do nothing when appending an empty map" in {
-      val map: SoyMap = SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("hello")), ("key2", SoyInt(12)), ("key2", SoyNull)))
-      val result = map ++ SoyMap(Seq())
+      val map: SoyMap = SoyMap(Map("key1" -> SoyNull, "key1" -> SoyString("hello"), "key2" -> SoyInt(12), "key2" -> SoyNull))
+      val result = map ++ SoyMap(Map())
       result === map
     }
     "append to an empty map" in {
-      val map: SoyMap = SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("hello")), ("key2", SoyInt(12)), ("key2", SoyNull)))
-      val result = SoyMap(Seq()) ++ map
+      val map: SoyMap = SoyMap(Map("key1" -> SoyNull, "key1" -> SoyString("hello"), "key2" -> SoyInt(12), "key2" -> SoyNull))
+      val result = SoyMap(Map()) ++ map
       result === map
     }
     "append values from the new map" in {
-      val map: SoyMap = SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("hello")), ("key2", SoyInt(12)), ("key2", SoyNull)))
-      val result = map ++ SoyMap(Seq(("key3", SoyString("world")), ("key4", SoyNull)))
-      result === SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("hello")), ("key2", SoyInt(12)), ("key2", SoyNull), ("key3", SoyString("world")), ("key4", SoyNull)))
+      val map: SoyMap = SoyMap(Map("key1" -> SoyNull, "key2" -> SoyInt(12)))
+      val result = map ++ SoyMap(Map("key3" -> SoyString("world"), "key4" -> SoyString("hello")))
+      result === SoyMap(Map("key1" -> SoyNull, "key2" -> SoyInt(12), "key3" -> SoyString("world"), "key4" -> SoyString("hello")))
     }
     "replace existing keys from the new map" in {
-      val map: SoyMap = SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("hello")), ("key2", SoyInt(12)), ("key2", SoyNull)))
-      val result = map ++ SoyMap(Seq(("key2", SoyString("world")), ("key4", SoyNull)))
-      result === SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("hello")), ("key2", SoyString("world")), ("key4", SoyNull)))
+      val map: SoyMap = SoyMap(Map("key1" -> SoyString("hello"), "key2" -> SoyInt(12)))
+      val result = map ++ SoyMap(Map("key2" -> SoyString("world"), "key4" -> SoyNull))
+      result === SoyMap(Map("key1" -> SoyString("hello"), "key2" -> SoyString("world"), "key4" -> SoyNull))
     }
     "cascade" in {
-      val map1: SoyMap = SoyMap(Seq(("key1", SoyString("value1"))))
-      val map2: SoyMap = SoyMap(Seq())
-      val map3: SoyMap = SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("value2")), ("key2", SoyInt(12))))
-      val map4: SoyMap = SoyMap(Seq(("key3", SoyInt(34)), ("key1", SoyString("value4")), ("key5", SoyNull)))
+      val map1: SoyMap = SoyMap(Map("key1" -> SoyString("value1")))
+      val map2: SoyMap = SoyMap(Map())
+      val map3: SoyMap = SoyMap(Map("key1" -> SoyNull, "key1" -> SoyString("value2"), "key2" -> SoyInt(12)))
+      val map4: SoyMap = SoyMap(Map("key3" -> SoyInt(34), "key1" -> SoyString("value4"), "key5" -> SoyNull))
       val result = map1 ++ map2 ++ map3 ++ map4
-      result === SoyMap(Seq(("key2", SoyInt(12)), ("key3", SoyInt(34)), ("key1", SoyString("value4")), ("key5", SoyNull)))
+      result === SoyMap(Map("key2" -> SoyInt(12), "key3" -> SoyInt(34), "key1" -> SoyString("value4"), "key5" -> SoyNull))
     }
   }
 
   "-" should {
     "not do anything on an empty map" in {
-      val map = SoyMap(Seq())
+      val map = SoyMap(Map())
       val result = map - "key1"
       result === map
     }
     "do nothing if the key is not in the map" in {
-      val map: SoyMap = SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("value2")), ("key2", SoyInt(12))))
+      val map: SoyMap = SoyMap(Map("key1" -> SoyString("value2"), "key2" -> SoyInt(12)))
       val result = map - "key3"
       result === map
     }
     "remove the existing key from the map" in {
-      val map: SoyMap = SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("value2")), ("key2", SoyInt(12))))
+      val map: SoyMap = SoyMap(Map("key1" -> SoyString("value2"), "key2" -> SoyInt(12)))
       val result = map - "key2"
-      result === SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("value2"))))
+      result === SoyMap(Map("key1" -> SoyString("value2")))
     }
     "all occurrences of a key from the map" in {
-      val map: SoyMap = SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("value2")), ("key2", SoyInt(12))))
+      val map: SoyMap = SoyMap(Map("key1" -> SoyNull, "key1" -> SoyString("value2"), "key2" -> SoyInt(12)))
       val result = map - "key1"
-      result === SoyMap(Seq(("key2", SoyInt(12))))
+      result === SoyMap(Map("key2" -> SoyInt(12)))
     }
     "cascade" in {
-      val map: SoyMap = SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("value2")), ("key2", SoyInt(12))))
+      val map: SoyMap = SoyMap(Map("key1" -> SoyNull, "key1" -> SoyString("value2"), "key2" -> SoyInt(12)))
       val result = map - "key2" - "key1"
-      result === SoyMap(Seq())
+      result === SoyMap(Map())
     }
   }
 
   "+" should {
     "append to an empty map" in {
-      val map = SoyMap(Seq())
-      val result = map + ("key1", SoyString("hello"))
-      result === SoyMap(Seq(("key1", SoyString("hello"))))
+      val map = SoyMap(Map())
+      val result = map + ("key1" -> SoyString("hello"))
+      result === SoyMap(Map("key1" -> SoyString("hello")))
     }
     "append to a map" in {
-      val map = SoyMap(Seq(("key1", SoyString("value1"))))
-      val result = map + ("key2", SoyString("value2"))
-      result === SoyMap(Seq(("key1", SoyString("value1")), ("key2", SoyString("value2"))))
+      val map = SoyMap(Map("key1" -> SoyString("value1")))
+      val result = map + ("key2" -> SoyString("value2"))
+      result === SoyMap(Map("key1" -> SoyString("value1"), "key2" -> SoyString("value2")))
     }
     "append to a map with an existing key" in {
-      val map = SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("hello")), ("key2", SoyInt(12)), ("key2", SoyNull)))
-      val result = map + ("key2", SoyString("value2"))
-      result === SoyMap(Seq(("key1", SoyNull), ("key1", SoyString("hello")), ("key2", SoyInt(12)), ("key2", SoyNull), ("key2", SoyString("value2"))))
+      val map = SoyMap(Map("key1" -> SoyString("hello"), "key2" -> SoyInt(12)))
+      val result = map + ("key2" -> SoyString("value2"))
+      result === SoyMap(Map("key1" -> SoyString("hello"), "key2" -> SoyString("value2")))
     }
     "cascade" in {
-      val map = SoyMap(Seq(("key1", SoyString("value1"))))
-      val result = map + ("key2", SoyString("value2")) + ("key3", SoyString("value3")) + ("key1", SoyString("value4"))
-      result === SoyMap(Seq(("key1", SoyString("value1")), ("key2", SoyString("value2")), ("key3", SoyString("value3")), ("key1", SoyString("value4"))))
+      val map = SoyMap(Map("key1" -> SoyString("value1")))
+      val result = map + ("key2" -> SoyString("value2")) + ("key3" -> SoyString("value3")) + ("key1" -> SoyString("value4"))
+      result === SoyMap(Map("key2" -> SoyString("value2"), "key3" -> SoyString("value3"), "key1" -> SoyString("value4")))
     }
   }
 }

--- a/src/test/scala/com/kinja/soy/SoyValueSpec.scala
+++ b/src/test/scala/com/kinja/soy/SoyValueSpec.scala
@@ -109,7 +109,7 @@ class SoyValueSpec extends Specification {
       value.toString must_== "[1, a, null, true]"
     }
     "build the wrapped Seq[SoyMap](items) as SoyListData" in {
-      val seq = Seq[SoyMap](SoyMap(Seq("a" -> SoyInt(1))), SoyMap(Seq("b" -> SoyInt(2), "c" -> SoyInt(3))))
+      val seq = Seq[SoyMap](SoyMap(Map("a" -> SoyInt(1))), SoyMap(Map("b" -> SoyInt(2), "c" -> SoyInt(3))))
       val value: Any = SoyList(seq).build
       value must beAnInstanceOf[SoyListData]
       value.toString must_== "[{a: 1}, {b: 2, c: 3}]"
@@ -118,26 +118,26 @@ class SoyValueSpec extends Specification {
 
   "SoyMap" should {
     "build the wrapped Seq() as SoyMapData" in {
-      val seq = Seq[(String, SoyValue)]()
-      val value: Any = SoyMap(seq).build
+      val map = Map[String, SoyValue]()
+      val value: Any = SoyMap(map).build
       value must beAnInstanceOf[SoyMapData]
       value.toString must_== "{}"
     }
     "build the wrapped Seq[String, SoyInt](items) as SoyMapData" in {
-      val seq = Seq[(String, SoyInt)]("a" -> SoyInt(1), "b" -> SoyInt(2), "c" -> SoyInt(3))
-      val value: Any = SoyMap(seq).build
+      val map = Map[String, SoyInt]("a" -> SoyInt(1), "b" -> SoyInt(2), "c" -> SoyInt(3))
+      val value: Any = SoyMap(map).build
       value must beAnInstanceOf[SoyMapData]
       value.toString must_== "{a: 1, b: 2, c: 3}"
     }
     "build the wrapped Seq[String, SoyValue](items) as SoyMapData" in {
-      val seq = Seq[(String, SoyValue)]("a" -> SoyInt(1), "b" -> SoyString("x"), "c" -> SoyNull, "d" -> SoyBoolean(false))
-      val value: Any = SoyMap(seq).build
+      val map = Map[String, SoyValue]("a" -> SoyInt(1), "b" -> SoyString("x"), "c" -> SoyNull, "d" -> SoyBoolean(false))
+      val value: Any = SoyMap(map).build
       value must beAnInstanceOf[SoyMapData]
       value.toString must_== "{a: 1, b: x, c: null, d: false}"
     }
     "build the wrapped Seq[String, SoyList](items) as SoyMapData" in {
-      val seq = Seq[(String, SoyList)]("a" -> SoyList(Seq(SoyInt(1), SoyInt(2))), "b" -> SoyList(Seq(SoyInt(4), SoyNull)), "c" -> SoyList(Seq[SoyDouble]()))
-      val value: Any = SoyMap(seq).build
+      val map = Map[String, SoyList]("a" -> SoyList(Seq(SoyInt(1), SoyInt(2))), "b" -> SoyList(Seq(SoyInt(4), SoyNull)), "c" -> SoyList(Seq[SoyDouble]()))
+      val value: Any = SoyMap(map).build
       value must beAnInstanceOf[SoyMapData]
       value.toString must_== "{a: [1, 2], b: [4, null], c: []}"
     }

--- a/src/test/scala/com/kinja/soy/SoyWritesSpec.scala
+++ b/src/test/scala/com/kinja/soy/SoyWritesSpec.scala
@@ -298,7 +298,7 @@ class SoyWritesSpec extends Specification {
     }
     "allow building complex lists using implicit writers" in {
       val none: Option[Int] = None
-      val soyValue = Soy.list(1, 2, "a", "b", 0, 12.5f, SoyList(Seq(SoyInt(6), SoyDouble(5))), 37.802, 'h', SoyMap(Seq("a" -> SoyNull)), Some("hello"), none, 444L)
+      val soyValue = Soy.list(1, 2, "a", "b", 0, 12.5f, SoyList(Seq(SoyInt(6), SoyDouble(5))), 37.802, 'h', SoyMap(Map("a" -> SoyNull)), Some("hello"), none, 444L)
       val expected = SoyList(Seq(
         SoyInt(1),
         SoyInt(2),
@@ -309,7 +309,7 @@ class SoyWritesSpec extends Specification {
         SoyList(Seq(SoyInt(6), SoyDouble(5))),
         SoyDouble(37.802),
         SoyString("h"),
-        SoyMap(Seq(("a", SoyNull))),
+        SoyMap(Map(("a", SoyNull))),
         SoyString("hello"),
         SoyNull,
         SoyString("444")))
@@ -320,7 +320,7 @@ class SoyWritesSpec extends Specification {
   "Soy.map()" should {
     "create an empty map" in {
       val soyValue = Soy.map()
-      soyValue must_== SoyMap(Seq())
+      soyValue must_== SoyMap(Map())
     }
     "allow building complex maps using implicit writers" in {
       val none: Option[Int] = None
@@ -334,9 +334,9 @@ class SoyWritesSpec extends Specification {
         "g" -> SoyNull,
         "h" -> '&',
         "i" -> none,
-        "i" -> SoyMap(Seq("aa" -> SoyString("aa1"), "bb" -> SoyString("bb1"))),
+        "i" -> SoyMap(Map("aa" -> SoyString("aa1"), "bb" -> SoyString("bb1"))),
         "j" -> Some(SoyList(Seq())))
-      val expected = SoyMap(Seq(
+      val expected = SoyMap(Map(
         "a" -> SoyInt(1),
         "b" -> SoyInt(2),
         "c" -> SoyInt(0),
@@ -346,7 +346,7 @@ class SoyWritesSpec extends Specification {
         "g" -> SoyNull,
         "h" -> SoyString("&"),
         "i" -> SoyNull,
-        "i" -> SoyMap(Seq("aa" -> SoyString("aa1"), "bb" -> SoyString("bb1"))),
+        "i" -> SoyMap(Map("aa" -> SoyString("aa1"), "bb" -> SoyString("bb1"))),
         "j" -> SoyList(Seq())))
       soyValue must_== expected
     }
@@ -355,21 +355,21 @@ class SoyWritesSpec extends Specification {
   "Soy.list() and Soy.map()" should {
     "allow composing complex data structures" in {
       val soyValue = testData
-      val expected = SoyMap(Seq(
+      val expected = SoyMap(Map(
         "simples" -> SoyList(Seq(SoyString("Simple(1)"), SoyString("Simple(2)"))),
-        "meta" -> SoyMap(Seq(
+        "meta" -> SoyMap(Map(
           "title" -> SoyString("test title"),
           "keywords" -> SoyList(Seq(SoyString("list"), SoyString("of"), SoyString("test"), SoyString("keywords"))),
-          "user" -> SoyMap(Seq(
+          "user" -> SoyMap(Map(
             "id" -> SoyString("9876543210"),
             "name" -> SoyString("test user"),
             "posts" -> SoyInt(250),
             "complex" -> SoyList(Seq(
-              SoyMap(Seq("a" -> SoyInt(5), "b" -> SoyString("5"), "c" -> SoyString("5"), "d" -> SoyString("Simple(5)"))),
-              SoyMap(Seq("a" -> SoyInt(6), "b" -> SoyString("6"), "c" -> SoyString("6"), "d" -> SoyString("Simple(6)"))),
-              SoyMap(Seq("a" -> SoyInt(7), "b" -> SoyString("7"), "c" -> SoyString("7"), "d" -> SoyString("Simple(7)"))))),
+              SoyMap(Map("a" -> SoyInt(5), "b" -> SoyString("5"), "c" -> SoyString("5"), "d" -> SoyString("Simple(5)"))),
+              SoyMap(Map("a" -> SoyInt(6), "b" -> SoyString("6"), "c" -> SoyString("6"), "d" -> SoyString("Simple(6)"))),
+              SoyMap(Map("a" -> SoyInt(7), "b" -> SoyString("7"), "c" -> SoyString("7"), "d" -> SoyString("Simple(7)"))))),
             "loggedIn" -> SoyBoolean(true))),
-          "features" -> SoyMap(Seq(
+          "features" -> SoyMap(Map(
             "feature1" -> SoyBoolean(true),
             "feature2" -> SoyBoolean(false),
             "feature3" -> SoyBoolean(true))))),


### PR DESCRIPTION
### What does this PR do? How does it affect users?

This PR switches the underlying type of SoyMap from `Seq[(String, SoyValue)]` to `Map[String, SoyValue]`.
### How should this be tested (feature switches, URLs, special user permissions)?

The code should compile and tests should run successfully.
### Related Trello card, wiki page or blog posts
