### PR TITLE
Remove SoyDouble and change SoyFloat to match Closure's actual type-matching.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "soy"
 organization := "com.kinja"
 
 // We use Semantic Versioning. See: http://semver.org/
-version := "1.0.3-SNAPSHOT"
+version := "2.0.0-SNAPSHOT"
 
 crossScalaVersions := Seq("2.10.4", "2.11.6")
 

--- a/src/main/scala/com/kinja/soy/SoyValue.scala
+++ b/src/main/scala/com/kinja/soy/SoyValue.scala
@@ -30,11 +30,7 @@ case class SoyInt(value: Int) extends AnyVal with SoyValue {
   @inline def build = value
 }
 
-case class SoyFloat(value: Float) extends AnyVal with SoyValue {
-  @inline def build = value
-}
-
-case class SoyDouble(value: Double) extends AnyVal with SoyValue {
+case class SoyFloat(value: Double) extends AnyVal with SoyValue {
   @inline def build = value
 }
 

--- a/src/main/scala/com/kinja/soy/SoyWrites.scala
+++ b/src/main/scala/com/kinja/soy/SoyWrites.scala
@@ -68,13 +68,6 @@ trait DefaultSoyWrites {
   }
 
   /**
-   * Converter for Float types.
-   */
-  implicit object FloatSoy extends SoyWrites[Float] {
-    def toSoy(o: Float) = SoyFloat(o)
-  }
-
-  /**
    * Converter for Double types.
    */
   implicit object DoubleSoy extends SoyWrites[Double] {

--- a/src/main/scala/com/kinja/soy/SoyWrites.scala
+++ b/src/main/scala/com/kinja/soy/SoyWrites.scala
@@ -78,7 +78,7 @@ trait DefaultSoyWrites {
    * Converter for Double types.
    */
   implicit object DoubleSoy extends SoyWrites[Double] {
-    def toSoy(o: Double) = SoyDouble(o)
+    def toSoy(o: Double) = SoyFloat(o)
   }
 
   /**

--- a/src/test/scala/com/kinja/soy/SoyValueSpec.scala
+++ b/src/test/scala/com/kinja/soy/SoyValueSpec.scala
@@ -55,40 +55,21 @@ class SoyValueSpec extends Specification {
 
   "SoyFloat" should {
     "build the wrapped +Float" in {
-      val floatValue: Float = 12.5f
+      val floatValue: Double = 12.5
       val value: Any = SoyFloat(floatValue).build
       value must_== floatValue
     }
     "build the wrapped 0" in {
-      val floatValue: Float = 0.0f
+      val floatValue: Double = 0.0
       val value: Any = SoyFloat(floatValue).build
       value must_== floatValue
     }
     "build the wrapped -Float" in {
-      val floatValue: Float = -34.5f
+      val floatValue: Double = -34.5
       val value: Any = SoyFloat(floatValue).build
       value must_== floatValue
     }
   }
-
-  "SoyDouble" should {
-    "build the wrapped +Double" in {
-      val doubleValue: Double = 12.5980
-      val value: Any = SoyDouble(doubleValue).build
-      value must_== doubleValue
-    }
-    "build the wrapped 0" in {
-      val doubleValue: Double = 0.0
-      val value: Any = SoyDouble(doubleValue).build
-      value must_== doubleValue
-    }
-    "build the wrapped -Double" in {
-      val doubleValue: Double = -34.2391
-      val value: Any = SoyDouble(doubleValue).build
-      value must_== doubleValue
-    }
-  }
-
   "SoyList" should {
     "build the wrapped Seq() as SoyListData" in {
       val seq = Seq[SoyValue]()
@@ -136,7 +117,7 @@ class SoyValueSpec extends Specification {
       value.toString must_== "{a: 1, b: x, c: null, d: false}"
     }
     "build the wrapped Seq[String, SoyList](items) as SoyMapData" in {
-      val map = Map[String, SoyList]("a" -> SoyList(Seq(SoyInt(1), SoyInt(2))), "b" -> SoyList(Seq(SoyInt(4), SoyNull)), "c" -> SoyList(Seq[SoyDouble]()))
+      val map = Map[String, SoyList]("a" -> SoyList(Seq(SoyInt(1), SoyInt(2))), "b" -> SoyList(Seq(SoyInt(4), SoyNull)), "c" -> SoyList(Seq[SoyFloat]()))
       val value: Any = SoyMap(map).build
       value must beAnInstanceOf[SoyMapData]
       value.toString must_== "{a: [1, 2], b: [4, null], c: []}"

--- a/src/test/scala/com/kinja/soy/SoyWritesSpec.scala
+++ b/src/test/scala/com/kinja/soy/SoyWritesSpec.scala
@@ -78,12 +78,6 @@ class SoyWritesSpec extends Specification {
       soyValue must beAnInstanceOf[SoyInt]
       soyValue.build must_== byteValue
     }
-    "be an implicit SoyWrites from Float to SoyFloat" in {
-      val floatValue: Float = 12
-      val soyValue = Soy.toSoy(floatValue)
-      soyValue must beAnInstanceOf[SoyFloat]
-      soyValue.build must_== floatValue
-    }
     "be an implicit SoyWrites from Double to SoyFloat" in {
       val doubleValue: Double = 12
       val soyValue = Soy.toSoy(doubleValue)
@@ -298,14 +292,14 @@ class SoyWritesSpec extends Specification {
     }
     "allow building complex lists using implicit writers" in {
       val none: Option[Int] = None
-      val soyValue = Soy.list(1, 2, "a", "b", 0, 12.5f, SoyList(Seq(SoyInt(6), SoyFloat(5))), 37.802, 'h', SoyMap(Map("a" -> SoyNull)), Some("hello"), none, 444L)
+      val soyValue = Soy.list(1, 2, "a", "b", 0, 12.5, SoyList(Seq(SoyInt(6), SoyFloat(5))), 37.802, 'h', SoyMap(Map("a" -> SoyNull)), Some("hello"), none, 444L)
       val expected = SoyList(Seq(
         SoyInt(1),
         SoyInt(2),
         SoyString("a"),
         SoyString("b"),
         SoyInt(0),
-        SoyFloat(12.5f),
+        SoyFloat(12.5),
         SoyList(Seq(SoyInt(6), SoyFloat(5))),
         SoyFloat(37.802),
         SoyString("h"),
@@ -328,7 +322,7 @@ class SoyWritesSpec extends Specification {
         "a" -> 1,
         "b" -> 2,
         "c" -> 0,
-        "d" -> 452.5f,
+        "d" -> 452.5,
         "e" -> 905.438098023,
         "f" -> SoyList(Seq(SoyFloat(56), SoyInt(4))),
         "g" -> SoyNull,

--- a/src/test/scala/com/kinja/soy/SoyWritesSpec.scala
+++ b/src/test/scala/com/kinja/soy/SoyWritesSpec.scala
@@ -84,10 +84,10 @@ class SoyWritesSpec extends Specification {
       soyValue must beAnInstanceOf[SoyFloat]
       soyValue.build must_== floatValue
     }
-    "be an implicit SoyWrites from Double to SoyDouble" in {
+    "be an implicit SoyWrites from Double to SoyFloat" in {
       val doubleValue: Double = 12
       val soyValue = Soy.toSoy(doubleValue)
-      soyValue must beAnInstanceOf[SoyDouble]
+      soyValue must beAnInstanceOf[SoyFloat]
       soyValue.build must_== doubleValue
     }
     "be an implicit SoyWrites from Char to SoyString" in {
@@ -298,7 +298,7 @@ class SoyWritesSpec extends Specification {
     }
     "allow building complex lists using implicit writers" in {
       val none: Option[Int] = None
-      val soyValue = Soy.list(1, 2, "a", "b", 0, 12.5f, SoyList(Seq(SoyInt(6), SoyDouble(5))), 37.802, 'h', SoyMap(Map("a" -> SoyNull)), Some("hello"), none, 444L)
+      val soyValue = Soy.list(1, 2, "a", "b", 0, 12.5f, SoyList(Seq(SoyInt(6), SoyFloat(5))), 37.802, 'h', SoyMap(Map("a" -> SoyNull)), Some("hello"), none, 444L)
       val expected = SoyList(Seq(
         SoyInt(1),
         SoyInt(2),
@@ -306,8 +306,8 @@ class SoyWritesSpec extends Specification {
         SoyString("b"),
         SoyInt(0),
         SoyFloat(12.5f),
-        SoyList(Seq(SoyInt(6), SoyDouble(5))),
-        SoyDouble(37.802),
+        SoyList(Seq(SoyInt(6), SoyFloat(5))),
+        SoyFloat(37.802),
         SoyString("h"),
         SoyMap(Map(("a", SoyNull))),
         SoyString("hello"),
@@ -330,7 +330,7 @@ class SoyWritesSpec extends Specification {
         "c" -> 0,
         "d" -> 452.5f,
         "e" -> 905.438098023,
-        "f" -> SoyList(Seq(SoyDouble(56), SoyInt(4))),
+        "f" -> SoyList(Seq(SoyFloat(56), SoyInt(4))),
         "g" -> SoyNull,
         "h" -> '&',
         "i" -> none,
@@ -341,8 +341,8 @@ class SoyWritesSpec extends Specification {
         "b" -> SoyInt(2),
         "c" -> SoyInt(0),
         "d" -> SoyFloat(452.5f),
-        "e" -> SoyDouble(905.438098023),
-        "f" -> SoyList(Seq(SoyDouble(56.0), SoyInt(4))),
+        "e" -> SoyFloat(905.438098023),
+        "f" -> SoyList(Seq(SoyFloat(56.0), SoyInt(4))),
         "g" -> SoyNull,
         "h" -> SoyString("&"),
         "i" -> SoyNull,


### PR DESCRIPTION
@pjrt The latest versions of Google Closure Templates have reduced support for `Float`s. They are now converted to `Double`s which produces surprising behavior like `2.1f` being printed as `2.0999999046325684` in a template.

As a consequence, I'm removing the support for floats from our wrappers. I'm also taking this opportunity to align our types with those in [Google's Documentation](https://developers.google.com/closure/templates/docs/java_usage) where `float` is represented by `Double`.
