### PR TITLE
duplicating the original macro to add a 'type' field for use in mantle

### DIFF
--- a/src/main/scala/com/kinja/soy/Soy.scala
+++ b/src/main/scala/com/kinja/soy/Soy.scala
@@ -63,4 +63,7 @@ object Soy {
    * Generates a SoyMapWrites[T] for a given case class T.
    */
   def writes[T]: SoyMapWrites[T] = macro SoyMacroImpl.writesImpl[T]
+
+  def typedWrites[T]: SoyMapWrites[T] = macro SoyMacroImpl.typedWritesImpl[T]
+
 }

--- a/src/test/scala/com/kinja/soy/TypedWritesMacroSpec.scala
+++ b/src/test/scala/com/kinja/soy/TypedWritesMacroSpec.scala
@@ -1,0 +1,15 @@
+package com.kinja.soy
+
+import org.scalatest.{ Matchers, FlatSpec }
+
+case class TypedClass(i: Int)
+
+class TypedWritesMacroSpec extends FlatSpec with Matchers {
+
+  implicit val tw = Soy.typedWrites[TypedClass]
+
+  it should "correctly add the type field to the result" in {
+    Soy.toSoy(TypedClass(1)) should be(Soy.map("i" -> 1, "type" -> "TypedClass"))
+  }
+
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds `Soy.typeWrites` that is identical to `Soy.writes` except it adds an additional `type` field with the supplied value.
### How should this be tested?

Change a Mantle class to use `Soy.typeWrites` and see if the soy output has the `type` field with the correct value
### [Related Trello card](https://trello.com/c/VWF6bNtO/142-create-a-soy-typedwrites-macro)
