### PR TITLE
Cross compile for all major Scala versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Scala data structures for Google Closure Templates
 
 This library allows contructing data structures in a similar style how
-[Play! Framework's JSON library](http://www.playframework.com/documentation/2.3.9/ScalaJson) allows building JSON,
+[Play! Framework's JSON library](https://www.playframework.com/documentation/latest/ScalaJson) allows building JSON,
 which can then be directly passed to the
-[Play! 2.3 plugin for Google Closure Templates](https://github.com/gawkermedia/play2-closure) for rendering.
+[Play! module for Google Closure Templates](https://github.com/gawkermedia/play2-closure) for rendering.
 The goal is to avoid passing template data as `Map[String, Any]` and use the Scala compiler's support for detecting
 mistakes.
 
@@ -11,7 +11,7 @@ mistakes.
 
 Add the following to your `build.sbt` file:
 ```scala
-libraryDependencies += "com.kinja" %% "soy" % "2.2.0"
+libraryDependencies += "com.kinja" %% "soy" % "4.0.0"
 ```
 
 ## Usage

--- a/build.sbt
+++ b/build.sbt
@@ -1,41 +1,44 @@
-// Project settings
+import scalariform.formatter.preferences._
 
 name := "soy"
 
 organization := "com.kinja"
 
 // We use Semantic Versioning. See: http://semver.org/
-version := "3.0.0"
+version := "4.0.0"
 
-scalaVersion := "2.11.8"
+crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.1")
+
+scalaVersion := crossScalaVersions.value.head
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 javacOptions ++= Seq("-Xlint:deprecation")
 
-shellPrompt in ThisBuild := { state => Project.extract(state).currentRef.project + "> " }
-
 // Dependencies
 
-libraryDependencies ++= Seq(
-	"com.google.template" % "soy" % "2016-08-09",
-	"org.specs2" %% "specs2-core" % "2.4.15" % "test",
-	"org.specs2" %% "specs2-mock" % "2.4.15" % "test",
-	"org.specs2" %% "specs2-junit" % "2.4.15" % "test",
-	"org.scalatest" %% "scalatest" % "2.2.1" % "test"
-)
+val specs2Version = "4.8.3"
 
-libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-compiler" % _)
+libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.4",
+	"com.google.template" % "soy" % "2016-08-09",
+	"org.specs2" %% "specs2-core" % specs2Version % "test",
+	"org.specs2" %% "specs2-mock" % specs2Version % "test",
+	"org.specs2" %% "specs2-junit" % specs2Version % "test",
+	"org.scalatest" %% "scalatest" % "3.1.1" % "test"
+)
 
 // Publishing
 
+lazy val secRing: String = System.getProperty("SEC_RING", "")
+lazy val pubRing: String = System.getProperty("PUB_RING", "")
+lazy val pgpPass: String = System.getProperty("PGP_PASS", "")
+
 credentials += Credentials(Path.userHome / ".ivy2" / ".sonatype")
-
-pgpSecretRing := file(System.getProperty("SEC_RING", ""))
-
-pgpPublicRing := file(System.getProperty("PUB_RING", ""))
-
-pgpPassphrase := Some(Array(System.getProperty("PGP_PASS", ""): _*))
+pgpSecretRing := file(secRing)
+pgpPublicRing := file(pubRing)
+pgpPassphrase := Some(Array(pgpPass: _*))
 
 pomExtra := {
   <url>https://github.com/gawkermedia/soy</url>
@@ -58,7 +61,3 @@ pomExtra := {
     </developer>
   </developers>
 }
-
-// External plugins
-
-com.typesafe.sbt.SbtScalariform.scalariformSettings

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,11 +2,8 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
-// The Typesafe repository
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
-
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")

--- a/src/main/scala/com/kinja/soy/SoyValue.scala
+++ b/src/main/scala/com/kinja/soy/SoyValue.scala
@@ -1,7 +1,7 @@
 package com.kinja.soy
 
 import com.google.template.soy.data._, restricted._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 
 /**

--- a/src/main/scala/com/kinja/soy/SoyWrites.scala
+++ b/src/main/scala/com/kinja/soy/SoyWrites.scala
@@ -119,8 +119,8 @@ trait DefaultSoyWrites {
   /**
    * Converter for Traversables types.
    */
-  implicit def traversableSoy[A: SoyWrites] = new SoyWrites[Traversable[A]] {
-    def toSoy(as: Traversable[A]) = SoyList(as.map(Soy.toSoy(_)).toSeq)
+  implicit def iterableSoy[A: SoyWrites] = new SoyWrites[Iterable[A]] {
+    def toSoy(as: Iterable[A]) = SoyList(as.map(Soy.toSoy(_)).toSeq)
   }
 
   /**

--- a/src/test/scala/com/kinja/soy/SoyValueSpec.scala
+++ b/src/test/scala/com/kinja/soy/SoyValueSpec.scala
@@ -73,25 +73,25 @@ class SoyValueSpec extends Specification {
   "SoyList" should {
     "build the wrapped Seq() as SoyListData" in {
       val seq = Seq[SoyValue]()
-      val value: Any = SoyList(seq).build
+      val value: AnyRef = SoyList(seq).build
       value must beAnInstanceOf[SoyListData]
       value.toString must_== "[]"
     }
     "build the wrapped Seq[SoyInt](items) as SoyListData" in {
       val seq = Seq[SoyInt](SoyInt(1), SoyInt(2), SoyInt(3))
-      val value: Any = SoyList(seq).build
+      val value: AnyRef = SoyList(seq).build
       value must beAnInstanceOf[SoyListData]
       value.toString must_== "[1, 2, 3]"
     }
     "build the wrapped Seq[SoyValue](items) as SoyListData" in {
       val seq = Seq[SoyValue](SoyInt(1), SoyString("a"), SoyNull, SoyBoolean(true))
-      val value: Any = SoyList(seq).build
+      val value: AnyRef = SoyList(seq).build
       value must beAnInstanceOf[SoyListData]
       value.toString must_== "[1, a, null, true]"
     }
     "build the wrapped Seq[SoyMap](items) as SoyListData" in {
       val seq = Seq[SoyMap](SoyMap(Map("a" -> SoyInt(1))), SoyMap(Map("b" -> SoyInt(2), "c" -> SoyInt(3))))
-      val value: Any = SoyList(seq).build
+      val value: AnyRef = SoyList(seq).build
       value must beAnInstanceOf[SoyListData]
       value.toString must_== "[{a: 1}, {b: 2, c: 3}]"
     }
@@ -100,25 +100,25 @@ class SoyValueSpec extends Specification {
   "SoyMap" should {
     "build the wrapped Seq() as SoyMapData" in {
       val map = Map[String, SoyValue]()
-      val value: Any = SoyMap(map).build
+      val value: AnyRef = SoyMap(map).build
       value must beAnInstanceOf[SoyMapData]
       value.toString must_== "{}"
     }
     "build the wrapped Seq[String, SoyInt](items) as SoyMapData" in {
       val map = Map[String, SoyInt]("a" -> SoyInt(1), "b" -> SoyInt(2), "c" -> SoyInt(3))
-      val value: Any = SoyMap(map).build
+      val value: AnyRef = SoyMap(map).build
       value must beAnInstanceOf[SoyMapData]
       value.toString must_== "{a: 1, b: 2, c: 3}"
     }
     "build the wrapped Seq[String, SoyValue](items) as SoyMapData" in {
       val map = Map[String, SoyValue]("a" -> SoyInt(1), "b" -> SoyString("x"), "c" -> SoyNull, "d" -> SoyBoolean(false))
-      val value: Any = SoyMap(map).build
+      val value: AnyRef = SoyMap(map).build
       value must beAnInstanceOf[SoyMapData]
       value.toString must_== "{a: 1, b: x, c: null, d: false}"
     }
     "build the wrapped Seq[String, SoyList](items) as SoyMapData" in {
       val map = Map[String, SoyList]("a" -> SoyList(Seq(SoyInt(1), SoyInt(2))), "b" -> SoyList(Seq(SoyInt(4), SoyNull)), "c" -> SoyList(Seq[SoyFloat]()))
-      val value: Any = SoyMap(map).build
+      val value: AnyRef = SoyMap(map).build
       value must beAnInstanceOf[SoyMapData]
       value.toString must_== "{a: [1, 2], b: [4, null], c: []}"
     }

--- a/src/test/scala/com/kinja/soy/SoyWritesSpec.scala
+++ b/src/test/scala/com/kinja/soy/SoyWritesSpec.scala
@@ -1,35 +1,41 @@
 package com.kinja.soy
 
 import org.specs2.mutable._
-import scala.collection.JavaConversions._
 import com.google.template.soy.data.{ SoyListData, SoyMapData }
 
-class SoyWritesSpec extends Specification {
+final case class Simple(value: Int)
 
-  case class Simple(value: Int)
+object Simple {
+  implicit val simpleSoy = new SimpleSoy
+}
 
-  case class Other(a: Int)
+final case class Other(a: Int)
 
-  case class Complex(a: Int, b: String, c: Long, d: Simple)
-
-  class SimpleSoy extends SoyWrites[Simple] {
-    def toSoy(simple: Simple): SoyValue = SoyString(simple.toString)
-  }
-
-  class ComplexSoy extends SoyWrites[Complex] {
-    def toSoy(complex: Complex): SoyValue = Soy.map(
-      "a" -> complex.a,
-      "b" -> complex.b,
-      "c" -> complex.c,
-      "d" -> complex.d)
-  }
-
+object Other {
   implicit val otherSoy = new SoyMapWrites[Other] {
     def toSoy(other: Other): SoyMap = Soy.map("a" -> other.a)
   }
+}
 
-  implicit val simpleSoy = new SimpleSoy
+final case class Complex(a: Int, b: String, c: Long, d: Simple)
+
+class SimpleSoy extends SoyWrites[Simple] {
+  def toSoy(simple: Simple): SoyValue = SoyString(simple.toString)
+}
+
+class ComplexSoy extends SoyWrites[Complex] {
+  def toSoy(complex: Complex): SoyValue = Soy.map(
+    "a" -> complex.a,
+    "b" -> complex.b,
+    "c" -> complex.c,
+    "d" -> complex.d)
+}
+
+object Complex {
   implicit val complexSoy = new ComplexSoy
+}
+
+class SoyWritesSpec extends Specification {
 
   val testData =
     Soy.map(
@@ -57,55 +63,55 @@ class SoyWritesSpec extends Specification {
     "be an implicit SoyWrites from String to SoyString" in {
       val stringValue: String = "test string"
       val soyValue = Soy.toSoy(stringValue)
-      soyValue must beAnInstanceOf[SoyString]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyString]
       soyValue.build must_== stringValue
     }
     "be an implicit SoyWrites from Int to SoyInt" in {
       val intValue: Int = 12
       val soyValue = Soy.toSoy(intValue)
-      soyValue must beAnInstanceOf[SoyInt]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyInt]
       soyValue.build must_== intValue
     }
     "be an implicit SoyWrites from Short to SoyInt" in {
       val shortValue: Short = 12
       val soyValue = Soy.toSoy(shortValue)
-      soyValue must beAnInstanceOf[SoyInt]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyInt]
       soyValue.build must_== shortValue
     }
     "be an implicit SoyWrites from Byte to SoyInt" in {
       val byteValue: Byte = 12
       val soyValue = Soy.toSoy(byteValue)
-      soyValue must beAnInstanceOf[SoyInt]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyInt]
       soyValue.build must_== byteValue
     }
     "be an implicit SoyWrites from Double to SoyFloat" in {
       val doubleValue: Double = 12
       val soyValue = Soy.toSoy(doubleValue)
-      soyValue must beAnInstanceOf[SoyFloat]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyFloat]
       soyValue.build must_== doubleValue
     }
     "be an implicit SoyWrites from Char to SoyString" in {
       val charValue: Char = '@'
       val soyValue = Soy.toSoy(charValue)
-      soyValue must beAnInstanceOf[SoyString]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyString]
       soyValue.build must_== charValue.toString
     }
     "be an implicit SoyWrites from BigInt to SoyString" in {
       val bigIntValue: BigInt = 12
       val soyValue = Soy.toSoy(bigIntValue)
-      soyValue must beAnInstanceOf[SoyString]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyString]
       soyValue.build must_== bigIntValue.toString
     }
     "be an implicit SoyWrites from BigDecimal to SoyString" in {
       val bigDecimalValue: BigDecimal = 12
       val soyValue = Soy.toSoy(bigDecimalValue)
-      soyValue must beAnInstanceOf[SoyString]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyString]
       soyValue.build must_== bigDecimalValue.toString
     }
     "be an implicit SoyWrites from Boolean to SoyBoolean" in {
       val booleanValue: Boolean = true
       val soyValue = Soy.toSoy(booleanValue)
-      soyValue must beAnInstanceOf[SoyBoolean]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyBoolean]
       soyValue.build must_== booleanValue
     }
 
@@ -113,83 +119,83 @@ class SoyWritesSpec extends Specification {
       val listValue: Array[Int] = Array()
       val soyValue = Soy.toSoy(listValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyList]
-      built must beAnInstanceOf[SoyListData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyList]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyListData]
       built.toString must_== "[]"
     }
     "be an implicit SoyWrites from Array[Int] to SoyList" in {
       val listValue: Array[Int] = Array(1, 2, 3, 4, 5, 6)
       val soyValue = Soy.toSoy(listValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyList]
-      built must beAnInstanceOf[SoyListData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyList]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyListData]
       built.toString must_== "[1, 2, 3, 4, 5, 6]"
     }
     "be an implicit SoyWrites from Array[String] to SoyList" in {
       val listValue: Array[String] = Array("a", "b", "c")
       val soyValue = Soy.toSoy(listValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyList]
-      built must beAnInstanceOf[SoyListData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyList]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyListData]
       built.toString must_== "[a, b, c]"
     }
     "be an implicit SoyWrites from List[Int] to SoyList" in {
       val listValue: List[Int] = List(1, 2, 3, 4, 5, 6)
       val soyValue = Soy.toSoy(listValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyList]
-      built must beAnInstanceOf[SoyListData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyList]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyListData]
       built.toString must_== "[1, 2, 3, 4, 5, 6]"
     }
     "be an implicit SoyWrites from Seq[Int] to SoyList" in {
       val listValue: Seq[Int] = Seq(1, 2, 3, 4, 5, 6)
       val soyValue = Soy.toSoy(listValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyList]
-      built must beAnInstanceOf[SoyListData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyList]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyListData]
       built.toString must_== "[1, 2, 3, 4, 5, 6]"
     }
     "be an implicit SoyWrites from Set[Int] to SoyList" in {
       val listValue: Set[Int] = Set(1, 2, 3, 4, 5, 6)
       val soyValue = Soy.toSoy(listValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyList]
-      built must beAnInstanceOf[SoyListData]
-      built.toString.sorted must_== "[1, 2, 3, 4, 5, 6]".sorted
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyList]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyListData]
+      built.toString.toSeq.sorted must_== "[1, 2, 3, 4, 5, 6]".toSeq.sorted
     }
     "be an implicit SoyWrites from Vector[Int] to SoyList" in {
       val listValue: Vector[Int] = Vector(1, 2, 3, 4, 5, 6)
       val soyValue = Soy.toSoy(listValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyList]
-      built must beAnInstanceOf[SoyListData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyList]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyListData]
       built.toString must_== "[1, 2, 3, 4, 5, 6]"
     }
-    "be an implicit SoyWrites from Traversable[Int] to SoyList" in {
-      val listValue: Traversable[Int] = List(1, 2, 3, 4, 5, 6)
+    "be an implicit SoyWrites from Iterable[Int] to SoyList" in {
+      val listValue: Iterable[Int] = List(1, 2, 3, 4, 5, 6)
       val soyValue = Soy.toSoy(listValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyList]
-      built must beAnInstanceOf[SoyListData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyList]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyListData]
       built.toString must_== "[1, 2, 3, 4, 5, 6]"
     }
-    "be an implicit SoyWrites from Traversable[Simple] to SoyList" in {
-      val listValue: Traversable[Simple] = List(Simple(1), Simple(2), Simple(3))
+    "be an implicit SoyWrites from Iterable[Simple] to SoyList" in {
+      val listValue: Iterable[Simple] = List(Simple(1), Simple(2), Simple(3))
       val soyValue = Soy.toSoy(listValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyList]
-      built must beAnInstanceOf[SoyListData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyList]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyListData]
       built.toString must_== "[Simple(1), Simple(2), Simple(3)]"
     }
-    "be an implicit SoyWrites from Traversable[Complex] to SoyList" in {
-      val listValue: Traversable[Complex] = List(
+    "be an implicit SoyWrites from Iterable[Complex] to SoyList" in {
+      val listValue: Iterable[Complex] = List(
         Complex(1, "a", 11L, Simple(111)),
         Complex(2, "b", 22L, Simple(222)),
         Complex(3, "c", 33L, Simple(333)))
       val soyValue = Soy.toSoy(listValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyList]
-      built must beAnInstanceOf[SoyListData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyList]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyListData]
       built.toString must_== "[{a: 1, b: a, c: 11, d: Simple(111)}, {a: 2, b: b, c: 22, d: Simple(222)}, {a: 3, b: c, c: 33, d: Simple(333)}]"
     }
 
@@ -197,24 +203,24 @@ class SoyWritesSpec extends Specification {
       val mapValue: Map[String, Int] = Map("a" -> 1, "b" -> 2, "c" -> 3)
       val soyValue = Soy.toSoy(mapValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyMap]
-      built must beAnInstanceOf[SoyMapData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyMap]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyMapData]
       built.toString must_== "{a: 1, b: 2, c: 3}"
     }
     "be an implicit SoyWrites from Map[String, String] to SoyMap" in {
       val mapValue: Map[String, String] = Map("a" -> "1", "b" -> "2", "c" -> "3")
       val soyValue = Soy.toSoy(mapValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyMap]
-      built must beAnInstanceOf[SoyMapData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyMap]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyMapData]
       built.toString must_== "{a: 1, b: 2, c: 3}"
     }
     "be an implicit SoyWrites from Map[String, Simple] to SoyMap" in {
       val mapValue: Map[String, Simple] = Map("a" -> Simple(1), "b" -> Simple(2), "c" -> Simple(3))
       val soyValue = Soy.toSoy(mapValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyMap]
-      built must beAnInstanceOf[SoyMapData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyMap]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyMapData]
       built.toString must_== "{a: Simple(1), b: Simple(2), c: Simple(3)}"
     }
     "be an implicit SoyWrites from Map[String, Complex] to SoyMap" in {
@@ -224,8 +230,8 @@ class SoyWritesSpec extends Specification {
         "c3" -> Complex(3, "c", 33L, Simple(333)))
       val soyValue = Soy.toSoy(mapValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyMap]
-      built must beAnInstanceOf[SoyMapData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyMap]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyMapData]
       built.toString must_== "{c1: {a: 1, b: a, c: 11, d: Simple(111)}, c2: {a: 2, b: b, c: 22, d: Simple(222)}, c3: {a: 3, b: c, c: 33, d: Simple(333)}}"
     }
 
@@ -240,7 +246,7 @@ class SoyWritesSpec extends Specification {
       val optionValue: Option[Int] = Some(12)
       val soyValue = Soy.toSoy(optionValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyInt]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyInt]
       built must_== optionValue.get
     }
     "be an implicit SoyWrites from Option[String] with None to SoyNull" in {
@@ -254,7 +260,7 @@ class SoyWritesSpec extends Specification {
       val optionValue: Option[String] = Some("test string")
       val soyValue = Soy.toSoy(optionValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyString]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyString]
       built must_== optionValue.get
     }
     "be an implicit SoyWrites from Option[Simple] with value to Simple" in {
@@ -262,7 +268,7 @@ class SoyWritesSpec extends Specification {
       val optionValue: Option[Simple] = Some(simpleValue)
       val soyValue = Soy.toSoy(optionValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyString]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyString]
       built must_== simpleValue.toString
     }
     "be an implicit SoyWrites from Option[Complex] with value to Complex" in {
@@ -270,8 +276,8 @@ class SoyWritesSpec extends Specification {
       val optionValue: Option[Complex] = Some(complexValue)
       val soyValue = Soy.toSoy(optionValue)
       val built = soyValue.build
-      soyValue must beAnInstanceOf[SoyMap]
-      built must beAnInstanceOf[SoyMapData]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyMap]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyMapData]
       built.toString must_== "{a: 1, b: a, c: 11, d: Simple(111)}"
     }
   }
@@ -280,7 +286,7 @@ class SoyWritesSpec extends Specification {
     "function as SoyWrites" in {
       val other = Other(5)
       val soyValue = Soy.toSoy(other)
-      soyValue must beAnInstanceOf[SoyValue]
+      soyValue.asInstanceOf[AnyRef] must beAnInstanceOf[SoyValue]
       soyValue must_== Soy.map("a" -> 5)
     }
   }
@@ -374,7 +380,7 @@ class SoyWritesSpec extends Specification {
     "build the composed complex data structure correctly" in {
       val soyValue = testData
       val built = soyValue.build
-      built must beAnInstanceOf[SoyMapData]
+      built.asInstanceOf[AnyRef] must beAnInstanceOf[SoyMapData]
       built.toString must_== "{simples: [Simple(1), Simple(2)], meta: {title: test title, keywords: [list, of, test, keywords], user: {name: test user, posts: 250, id: 9876543210, loggedIn: true, complex: [{a: 5, b: 5, c: 5, d: Simple(5)}, {a: 6, b: 6, c: 6, d: Simple(6)}, {a: 7, b: 7, c: 7, d: Simple(7)}]}, features: {feature1: true, feature2: false, feature3: true}}, views: 1349, footerHtml: null}"
     }
   }

--- a/src/test/scala/com/kinja/soy/TypedWritesMacroSpec.scala
+++ b/src/test/scala/com/kinja/soy/TypedWritesMacroSpec.scala
@@ -1,10 +1,11 @@
 package com.kinja.soy
 
-import org.scalatest.{ Matchers, FlatSpec }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 case class TypedClass(i: Int)
 
-class TypedWritesMacroSpec extends FlatSpec with Matchers {
+class TypedWritesMacroSpec extends AnyFlatSpec with Matchers {
 
   implicit val tw = Soy.typedWrites[TypedClass]
 

--- a/src/test/scala/com/kinja/soy/WritesMacroSpec.scala
+++ b/src/test/scala/com/kinja/soy/WritesMacroSpec.scala
@@ -1,6 +1,7 @@
 package com.kinja.soy
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 case class Id[A](key: Int)
 
@@ -33,7 +34,7 @@ object MultipleApplies {
   def apply(s: String): MultipleApplies = apply(s.length)
 }
 
-class WritesMacroSpec extends FlatSpec with Matchers {
+class WritesMacroSpec extends AnyFlatSpec with Matchers {
   implicit def Id_Soy[A] = new SoyWrites[Id[A]] {
     def toSoy(id: Id[A]): SoyValue = SoyInt(id.key)
   }


### PR DESCRIPTION
* Upgrade library versions to latest ones in order to support Scala versions
* Fix compiler warnings
* Use the Scala collection compat library to support Scala 2.13
* Replace `Traversable` with `Iterable` (potentially breaking changes, thus the major version bump)
* The `NotNull` trait was removed, we need to do a runtime `null` check instead
* Upgrade sbt